### PR TITLE
test 0.3 and 0.4 separately on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
     - osx
     - linux
 julia:
-    - release
+    - 0.3
+    - 0.4
     - nightly
 notifications:
     email: false


### PR DESCRIPTION
release is 0.4 now, and the package still supports 0.3 according to REQUIRE
