### PR TITLE
__precompile__  not needed

### DIFF
--- a/src/SGP4.jl
+++ b/src/SGP4.jl
@@ -1,8 +1,6 @@
 # Julia wrapper for the sgp4 Python library:
 # https://pypi.python.org/pypi/sgp4/
 
-__precompile__()
-
 module SGP4
 
 using PyCall, Dates


### PR DESCRIPTION
It's the default starting in `julia v0.7`